### PR TITLE
use shlex instead of split whitespaces.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ ipstack = { version = "0.1" }
 log = { version = "0.4", features = ["std"] }
 mimalloc = { version = "0.1", default-features = false, optional = true }
 percent-encoding = "2"
+shlex = "1.3.0"
 socks5-impl = { version = "0.6", default-features = false, features = [
     "tokio",
 ] }
@@ -53,7 +54,6 @@ tun = { version = "0.7", features = ["async"] }
 udp-stream = { version = "0.0.12", default-features = false }
 unicase = "2"
 url = "2"
-shlex = "1.3.0"
 
 [build-dependencies]
 serde_json = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ tun = { version = "0.7", features = ["async"] }
 udp-stream = { version = "0.0.12", default-features = false }
 unicase = "2"
 url = "2"
-shell-words = "1.1.0"
+shlex = "1.3.0"
 
 [build-dependencies]
 serde_json = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ tun = { version = "0.7", features = ["async"] }
 udp-stream = { version = "0.0.12", default-features = false }
 unicase = "2"
 url = "2"
+shell-words = "1.1.0"
 
 [build-dependencies]
 serde_json = "1"

--- a/src/general_api.rs
+++ b/src/general_api.rs
@@ -2,8 +2,8 @@ use crate::{
     args::{ArgDns, ArgProxy},
     ArgVerbosity, Args,
 };
-use std::os::raw::{c_char, c_int, c_ushort};
 use shell_words::split;
+use std::os::raw::{c_char, c_int, c_ushort};
 static TUN_QUIT: std::sync::Mutex<Option<tokio_util::sync::CancellationToken>> = std::sync::Mutex::new(None);
 
 /// # Safety

--- a/src/general_api.rs
+++ b/src/general_api.rs
@@ -3,7 +3,7 @@ use crate::{
     ArgVerbosity, Args,
 };
 use std::os::raw::{c_char, c_int, c_ushort};
-
+use shell_words::split;
 static TUN_QUIT: std::sync::Mutex<Option<tokio_util::sync::CancellationToken>> = std::sync::Mutex::new(None);
 
 /// # Safety
@@ -88,7 +88,7 @@ pub unsafe extern "C" fn tun2proxy_run_with_cli_args(cli_args: *const c_char, tu
     let Ok(cli_args) = std::ffi::CStr::from_ptr(cli_args).to_str() else {
         return -5;
     };
-    let args = <Args as ::clap::Parser>::parse_from(cli_args.split_whitespace());
+    let args = <Args as ::clap::Parser>::parse_from(split(cli_args).expect("failed to split cli args"));
     general_run_for_api(args, tun_mtu, packet_information)
 }
 


### PR DESCRIPTION
If the arguments are: `"D:\Tun2Proxy App\sample.exe" --proxy "socks5://1.2.3.4:1080"`, they will be split using `split_whitespaces()` into the vector `["\"D:\\Tun2Proxy", "App\\sample.exe\"", "--proxy", "socks5://1.2.3.4:1080"]`.
To solve this problem, I use the `shlex` dependency.
