### PR TITLE
feat(android): add udpgw_server parameter to JNI run()

### DIFF
--- a/src/android.rs
+++ b/src/android.rs
@@ -21,6 +21,9 @@ use jni::{
 /// - tun_mtu: the tun mtu
 /// - dns_strategy: the dns strategy, see ArgDns enum
 /// - verbosity: the verbosity level, see ArgVerbosity enum
+/// - udpgw_server: optional udpgw server address (e.g. "198.18.0.1:7300"),
+///   empty string to disable. When set, UDP packets are forwarded via the
+///   udpgw protocol through a TCP connection to this address.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn Java_com_github_shadowsocks_bg_Tun2proxy_run(
     mut env: EnvUnowned<'_>,
@@ -31,6 +34,7 @@ pub unsafe extern "C" fn Java_com_github_shadowsocks_bg_Tun2proxy_run(
     tun_mtu: jchar,
     verbosity: jint,
     dns_strategy: jint,
+    udpgw_server: JString<'_>,
 ) -> jint {
     let dns = dns_strategy.try_into().unwrap();
     let verbosity = verbosity.try_into().unwrap();
@@ -52,6 +56,18 @@ pub unsafe extern "C" fn Java_com_github_shadowsocks_bg_Tun2proxy_run(
             .close_fd_on_drop(close_fd_on_drop)
             .dns(dns)
             .verbosity(verbosity);
+
+        #[cfg(feature = "udpgw")]
+        {
+            let udpgw_str = get_java_string(env, &udpgw_server).unwrap_or_default();
+            if !udpgw_str.is_empty() {
+                if let Ok(addr) = udpgw_str.parse::<std::net::SocketAddr>() {
+                    args.udpgw_server(addr);
+                    log::info!("udpgw_server={}", addr);
+                }
+            }
+        }
+
         let v = crate::general_api::general_run_for_api(args, tun_mtu, false);
         Ok::<jint, Error>(v)
     })


### PR DESCRIPTION
## Summary

Adds an optional `udpgw_server` JString parameter to the Android JNI `run()` function, enabling Android apps to configure UDP forwarding via the existing udpgw support without resorting to `tun2proxy_run_with_cli_args` or forking the crate.

## Motivation

Android VPN apps using tun2proxy via JNI currently have no way to pass `--udpgw-server` to the `run()` entry point. The only options are:
1. Call `tun2proxy_run_with_cli_args` via dlsym — fragile, and the force-exit timeout thread kills the Android process
2. Fork/vendor tun2proxy — maintainers of downstream projects (e.g. [MasterHttpRelayVPN-RUST](https://github.com/therealaleph/MasterHttpRelayVPN-RUST)) have explicitly rejected this pattern

Adding the parameter to the JNI function is the clean solution — 13 lines, no new dependencies, gated behind `#[cfg(feature = "udpgw")]`.

## Changes

`src/android.rs`:
- Added `udpgw_server: JString<'_>` parameter to `Java_com_github_shadowsocks_bg_Tun2proxy_run`
- When the udpgw feature is enabled and the string is non-empty, parses it as `SocketAddr` and calls `args.udpgw_server(addr)`
- When the feature is disabled, the parameter is accepted but ignored

## Use case

This enables UDP forwarding (DNS, QUIC, VoIP calls) through a tunnel-node's udpgw handler. The Android app passes something like `"198.18.0.1:7300"` as the udpgw server address, and tun2proxy opens a TCP connection to it through the SOCKS5 proxy, multiplexing all UDP flows via the udpgw wire protocol.

## Compatibility

The JNI function signature changes (one additional parameter). Callers must update their Kotlin/Java `external fun` declarations to include the new `udpgwServer: String` parameter. Passing an empty string preserves the previous behavior.