### PR TITLE
cli: add --mtu flag for tun2proxy-bin

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -104,6 +104,14 @@ pub struct Args {
     #[arg(short, long, value_name = "IP/CIDR")]
     pub bypass: Vec<IpCidr>,
 
+    /// MTU of the TUN device. Userspace TCP stack uses (MTU - 40) as the
+    /// effective MSS for synthesized segments going to the kernel side, so
+    /// lower this when the kernel forwards the traffic onwards through a
+    /// link with a smaller MTU (e.g. a WireGuard tunnel at 1420) to avoid
+    /// having the bigger segments silently dropped.
+    #[arg(long, value_name = "bytes", default_value_t = tun::DEFAULT_MTU)]
+    pub mtu: u16,
+
     /// TCP timeout in seconds
     #[arg(long, value_name = "seconds", default_value = "600")]
     pub tcp_timeout: u64,
@@ -181,6 +189,7 @@ impl Default for Args {
             dns: ArgDns::default(),
             dns_addr: "8.8.8.8".parse().unwrap(),
             bypass: vec![],
+            mtu: tun::DEFAULT_MTU,
             tcp_timeout: 600,
             udp_timeout: 10,
             verbosity: ArgVerbosity::Info,

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -77,7 +77,8 @@ async fn main_async(args: Args) -> Result<(), BoxError> {
             }
             unsafe { tun2proxy::tun2proxy_set_traffic_status_callback(1, Some(traffic_cb), std::ptr::null_mut()) };
 
-            let ret = tun2proxy::general_run_async(args, tun::DEFAULT_MTU, cfg!(target_os = "macos"), shutdown_token).await;
+            let mtu = args.mtu;
+            let ret = tun2proxy::general_run_async(args, mtu, cfg!(target_os = "macos"), shutdown_token).await;
             if let Err(err) = &ret {
                 log::error!("main loop error: {err}");
             }


### PR DESCRIPTION
## Summary

`tun2proxy-bin` always hands `tun::DEFAULT_MTU` to `general_run_async`, and the userspace TCP stack then derives the MSS of segments written into the TUN device from that value. When the TUN traffic is forwarded onwards over a link with a smaller MTU, the kernel either fragments (slow) or, with the DF bit set, silently drops segments larger than the next-hop MTU. The resulting black hole is hard to diagnose because the proxy-side TCP keeps looking healthy end to end.

This adds the missing CLI knob to set the value at startup. The default is `tun::DEFAULT_MTU`, so behaviour for existing users is unchanged.

## Background

The C/JNI shims in `general_api.rs` already accept a `tun_mtu` parameter:

```rust
pub unsafe extern "C" fn tun2proxy_run_with_cli_args(
    cli_args: *const c_char,
    tun_mtu: c_ushort,
    packet_information: bool,
) -> c_int { ... }
```

So the only thing missing was exposing the same value through `clap`. This patch adds a `--mtu <bytes>` flag to `Args` with `default_value_t = tun::DEFAULT_MTU`, and lets `tun2proxy::main` pass `args.mtu` instead of the hard-coded constant.

## Concrete trigger

The motivating deployment routes VM traffic through `tun2proxy-bin` and then onwards through a WireGuard tunnel at MTU 1420. Without the flag the userspace stack hands the kernel `DEFAULT_MTU`-sized segments, the kernel cannot fit them in the 1420-byte WireGuard frame, and the connection appears as "TLS handshake succeeded then nothing":

```
$ curl -v https://1.1.1.1/...
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.3 (IN), TLS change cipher, Change cipher spec (1):
... silence ...
* Connection timed out
```

With `--mtu 1420` the userspace stack hands the kernel 1380-byte segments, those fit in the WireGuard frame, and the connection completes normally.

## Tests

I did not add a unit test for this. The change is a pure plumbing patch (one new clap field, one variable name in `bin/main.rs`) and the underlying machinery is already exercised by the C-API path. Happy to add one if you want.

---

Signed-off-by: DL6ER <dl6er@dl6er.de>
