### PR TITLE
 fixed  `--dns virtual` not work in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,11 +25,10 @@ FROM rust:latest AS musl-builder
         && rustup target add "$ARCH-unknown-linux-musl" \
         && cargo build --release --target "$ARCH-unknown-linux-musl"
 
-    RUN mkdir /.etc \
-        && touch /.etc/resolv.conf \
-        && mkdir /.tmp \
-        && chmod 777 /.tmp \
-        && chmod +t /.tmp
+    RUN mkdir -p etc tmp \
+        && touch etc/resolv.conf \
+        && chmod 777 tmp \
+        && chmod +t tmp
 
 ####################################################################################################
 ## Alpine image

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,7 +139,15 @@ async fn create_tcp_stream(socket_queue: &Option<Arc<SocketQueue>>, peer: Socket
 
 async fn create_udp_stream(socket_queue: &Option<Arc<SocketQueue>>, peer: SocketAddr) -> std::io::Result<UdpStream> {
     match &socket_queue {
-        None => UdpStream::connect(peer).await,
+        None => {
+            let bind_addr = match peer {
+                SocketAddr::V4(_) => SocketAddr::from(([0, 0, 0, 0], 0)),
+                SocketAddr::V6(_) => SocketAddr::from(([0, 0, 0, 0, 0, 0, 0, 0], 0)),
+            };
+            let socket = UdpSocket::bind(bind_addr).await?;
+            socket.connect(peer).await?;
+            UdpStream::from_tokio(socket, peer).await
+        }
         Some(queue) => {
             let socket = queue.recv_udp(peer.ip().into()).await?;
             socket.connect(peer).await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,8 +141,8 @@ async fn create_udp_stream(socket_queue: &Option<Arc<SocketQueue>>, peer: Socket
     match &socket_queue {
         None => {
             let bind_addr = match peer {
-                SocketAddr::V4(_) => SocketAddr::from(([0, 0, 0, 0], 0)),
-                SocketAddr::V6(_) => SocketAddr::from(([0, 0, 0, 0, 0, 0, 0, 0], 0)),
+                SocketAddr::V4(_) => SocketAddr::from((std::net::Ipv4Addr::UNSPECIFIED, 0)),
+                SocketAddr::V6(_) => SocketAddr::from((std::net::Ipv6Addr::UNSPECIFIED, 0)),
             };
             let socket = UdpSocket::bind(bind_addr).await?;
             socket.connect(peer).await?;


### PR DESCRIPTION
Refactor Dockerfile directory creation and enhance UDP stream handling in lib.rs ， fixed  `--dns virtual` not work in docker