### PR TITLE
tcp: expose advertised MSS via --tcp-mss to fix ClientHello fragmentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Options:
   -b, --bypass <IP/CIDR>                   IPs used in routing setup which should bypass the tunnel, in the form of IP or IP/CIDR.
                                            Multiple IPs can be specified, e.g. --bypass 3.4.5.0/24 --bypass 5.6.7.8
       --tcp-timeout <seconds>              TCP timeout in seconds [default: 600]
+      --tcp-mss <bytes>                    MSS advertised in the SYN-ACK to the kernel side [default: none]
       --udp-timeout <seconds>              UDP timeout in seconds [default: 10]
   -v, --verbosity <level>                  Verbosity level [default: info] [possible values: off, error, warn, info, debug, trace]
       --daemonize                          Daemonize for unix family or run as Windows service

--- a/src/args.rs
+++ b/src/args.rs
@@ -116,6 +116,14 @@ pub struct Args {
     #[arg(long, value_name = "seconds", default_value = "600")]
     pub tcp_timeout: u64,
 
+    /// MSS advertised in the SYN-ACK to the kernel side. By default the userspace
+    /// stack sends no MSS option, so the peer OS falls back to its own default
+    /// (e.g. 512 on macOS), fragmenting large first segments such as a TLS
+    /// ClientHello. Set this to the tunnel's (MTU - 40) to let the peer send big
+    /// segments. `None` keeps the previous behaviour (no option advertised).
+    #[arg(long, value_name = "bytes")]
+    pub tcp_mss: Option<u16>,
+
     /// UDP timeout in seconds
     #[arg(long, value_name = "seconds", default_value = "10")]
     pub udp_timeout: u64,
@@ -191,6 +199,7 @@ impl Default for Args {
             bypass: vec![],
             mtu: tun::DEFAULT_MTU,
             tcp_timeout: 600,
+            tcp_mss: None,
             udp_timeout: 10,
             verbosity: ArgVerbosity::Info,
             virtual_dns_pool: IpCidr::from_str("198.18.0.0/15").unwrap(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,6 +243,9 @@ where
     ipstack_config.mtu(mtu)?;
     let mut tcp_cfg = ipstack::TcpConfig::default();
     tcp_cfg.timeout = std::time::Duration::from_secs(args.tcp_timeout);
+    if let Some(mss) = args.tcp_mss {
+        tcp_cfg.options = Some(vec![ipstack::TcpOptions::MaximumSegmentSize(mss)]);
+    }
     ipstack_config.with_tcp_config(tcp_cfg);
     ipstack_config.udp_timeout(std::time::Duration::from_secs(args.udp_timeout));
 


### PR DESCRIPTION
## Problem

`ipstack` answers the SYN-ACK to the kernel side **without a MSS option**. When a peer has no MSS offer, the OS falls back to its own default — `net.inet.tcp.mssdflt` = **512** on macOS — so a large first segment such as a TLS **ClientHello** is split across many 512-byte segments.

Downstream consumers that sniff the SNI from the *first* read (transparent proxy routers, sniffers) then miss the domain on the fragmented handshake.

`tcpdump` on the utun, **before** (no way to advertise MSS):

```
Flags [S.], win 16384, length 0          # SYN-ACK, no options at all
... 512, 512, 499, 512 ...               # ClientHello split into 512B segments
```

**after** (`--tcp-mss 8960`, MTU 9000):

```
Flags [S.], win 16384, options [mss 8960], length 0
```

The peer now sends the ClientHello in a single segment. In our downstream SNI-based router this took domain recognition from ~42% loss to ~0 on the same hosts.

## Fix

`ipstack::TcpConfig.options` is already public and `TcpOptions::MaximumSegmentSize` already exists — the value simply is never wired up. This adds an optional `Args.tcp_mss` and passes it through, mirroring exactly how `--tcp-timeout` sets `TcpConfig.timeout`:

```rust
let mut tcp_cfg = ipstack::TcpConfig::default();
tcp_cfg.timeout = std::time::Duration::from_secs(args.tcp_timeout);
if let Some(mss) = args.tcp_mss {
    tcp_cfg.options = Some(vec![ipstack::TcpOptions::MaximumSegmentSize(mss)]);
}
```

- Default is `None` → **no behaviour change** unless the flag is set (runtime no-op otherwise).
- Cross-platform: it fixes the fragmentation at the source, so it also helps on Android/iOS where a system-wide MSS knob isn't available.
- README options table updated.

`cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings` and the build are clean locally.

## Note on semver

This adds a field to `Args`, which is not `#[non_exhaustive]`, so `cargo-semver-checks` will report it as a major change. I kept the change minimal and did not touch the struct's attributes — happy to add `#[non_exhaustive]` to `Args` or let it ride to the next minor bump, whichever you prefer.
